### PR TITLE
Improvements to being able to setup databases and automatic table creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 docs
 .idea
 npm-debug.log
-db_config.js
 node_modules
+db_config.json

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 .PHONY: test
 
 test:
-	./node_modules/.bin/mocha -u tdd
+	NODE_ENV=test ./node_modules/.bin/mocha -u tdd

--- a/app.js
+++ b/app.js
@@ -50,8 +50,7 @@ app.use(function(req, res, next) {
 // error handlers
 // development error handler
 // will print stacktrace
-
-if (app.get('env') === 'development') {
+if (app.get('env') === 'development' || app.get('env') === 'test') {
   app.use(function(err, req, res, next) {
     res.status(err.status || 500);
     res.json({statusCode: (err.status || 500), message: err.message})

--- a/bin/www
+++ b/bin/www
@@ -7,6 +7,7 @@
 var app = require('../app');
 var debug = require('debug')('CMPT--CTPv2:server');
 var http = require('http');
+var database = require('./../modules/database');
 
 /**
  * Get port from environment and store in Express.
@@ -25,9 +26,19 @@ var server = http.createServer(app);
  * Listen on provided port, on all network interfaces.
  */
 
-server.listen(port);
-server.on('error', onError);
-server.on('listening', onListening);
+if (process.env.NODE_ENV == 'test' || process.env.FORCE_DROP) {
+	database.dropTables(function() {
+		database.createTables(listen);
+	});
+} else {
+	database.createTables(listen);
+}
+
+function listen() {
+	server.listen(port);
+	server.on('error', onError);
+	server.on('listening', onListening);
+}
 
 /**
  * Normalize a port into a number, string, or false.

--- a/db_config.json
+++ b/db_config.json
@@ -1,0 +1,20 @@
+{
+  "test": {
+    "host": "",
+    "user": "",
+    "password": "",
+    "database": ""
+  },
+  "development": {
+    "host": "",
+    "user": "",
+    "password": "",
+    "database": ""
+  },
+  "production": {
+    "host": "",
+    "user": "",
+    "password": "",
+    "database": ""
+  }
+}

--- a/modules/comments.js
+++ b/modules/comments.js
@@ -1,6 +1,6 @@
 var express = require('express');
 var path = require('path');
-var database = require('./../db_config.js');
+var database = require('./database.js');
 
 
 //gets a specific comment

--- a/modules/database.js
+++ b/modules/database.js
@@ -1,0 +1,93 @@
+var fs = require('fs');
+var mysql = require('mysql');
+var file = fs.readFileSync('db_config.json', 'utf8');
+var json = JSON.parse(file);
+
+var environment = process.env.NODE_ENV;
+if (environment == undefined) environment = 'development';
+exports.db = mysql.createConnection(json[environment]);
+
+// The following database connection shouldn't be used anywhere else as it allows multiple statements
+// which are UNSAFE if user input is added.
+var options = json[environment];
+options.multipleStatements = true;
+var database = mysql.createConnection(options);
+
+exports.createTables = function(callback) {
+	var query = `
+	CREATE TABLE IF NOT EXISTS USERS
+	(
+	U_ID INTEGER NOT NULL AUTO_INCREMENT,
+	EMAIL varchar(50) NOT NULL UNIQUE,
+	PASSWORD varchar(60) NOT NULL,
+	FIRST_NAME varchar(50) NOT NULL,
+	LAST_NAME varchar(50) NOT NULL,
+	BIO text,
+	PRIMARY KEY(U_ID)
+	);
+
+	CREATE TABLE IF NOT EXISTS DOCUMENTS
+	(
+	DOC_ID INTEGER NOT NULL AUTO_INCREMENT,
+	OWNER_ID INTEGER,
+	EXTENSIONS varchar(50) NOT NULL,
+	DESCRIPTION varchar(50) NOT NULL,
+	TITLE varchar(50) NOT NULL,
+	PREVIEW varchar(10),
+	AVG_RATING FLOAT,
+	PROVINCE varchar(50),
+	GRADE varchar(10),
+	SUBJECT varchar(20),
+	FOREIGN KEY (OWNER_ID) REFERENCES USERS (U_ID),
+	PRIMARY KEY(DOC_ID)
+	);
+
+	CREATE TABLE IF NOT EXISTS RATING
+	(
+	USER_REVIEWED_BY INTEGER,
+	OWNER INTEGER,
+	RATING INTEGER,
+	DOC_ID INTEGER NOT NULL,
+	FOREIGN KEY (DOC_ID) REFERENCES DOCUMENTS(DOC_ID) ON DELETE CASCADE,
+	FOREIGN KEY (OWNER) REFERENCES USERS (U_ID),
+	FOREIGN KEY (USER_REVIEWED_BY) REFERENCES USERS (U_ID),
+	PRIMARY KEY  (USER_REVIEWED_BY, DOC_ID)
+	);
+
+	CREATE TABLE IF NOT EXISTS DOWNLOADS
+	(
+	DOWNLOADER INTEGER REFERENCES USERS(U_ID),
+	DOC_ID INTEGER REFERENCES DOCUMENTS(DOC_ID),
+	TIMESTAMP TIME,
+	FOREIGN KEY (DOWNLOADER) REFERENCES USERS (U_ID),
+	FOREIGN KEY (DOC_ID) REFERENCES DOCUMENTS (DOC_ID),
+	PRIMARY KEY(DOWNLOADER, DOC_ID)
+	);
+
+	CREATE TABLE IF NOT EXISTS COMMENTS
+	(
+	COMMENT_ID INTEGER NOT NULL AUTO_INCREMENT,
+	DOC_ID INTEGER NOT NULL,
+	OWNER INTEGER REFERENCES USERS(U_ID),
+	COMMENT VARCHAR(150),
+	FOREIGN KEY (DOC_ID) REFERENCES DOCUMENTS(DOC_ID) ON DELETE CASCADE,
+	FOREIGN KEY (OWNER) REFERENCES USERS (U_ID),
+	PRIMARY KEY(COMMENT_ID)
+	);
+	`;
+	database.query(query, function(err) {
+		if (err) throw err;
+		callback();
+	});
+};
+
+exports.dropTables = function(callback) {
+	query = `
+	DROP TABLE IF EXISTS RATING, DOWNLOADS, COMMENTS, DOCUMENTS, USERS
+	`;
+
+	database.query(query, function(err) {
+		if (err) throw err;
+		callback();
+	});
+};

--- a/modules/documents.js
+++ b/modules/documents.js
@@ -1,4 +1,4 @@
-var database = require('./../db_config.js');
+var database = require('./database.js');
 var path = require('path');
 var fs = require('fs');
 var multer = require('multer');

--- a/modules/ratings.js
+++ b/modules/ratings.js
@@ -1,5 +1,5 @@
 var express = require('express');
-var database = require('./../db_config.js');
+var database = require('./database.js');
 
 
 exports.retrieveSpecific = function(req, res) {

--- a/modules/users.js
+++ b/modules/users.js
@@ -1,5 +1,5 @@
 var express = require('express')
-var database = require('./../db_config.js');
+var database = require('./database.js');
 var bcrypt = require('bcryptjs');
 
 function sendResponse(res, code, data) {

--- a/test/users.js
+++ b/test/users.js
@@ -1,14 +1,14 @@
 var rest = require('restler');
 var assert = require('assert');
-var database = require('./../db_config');
+var database = require('./../modules/database');
 
 var base_url = 'http://localhost:3000/api/v1/users';
 
 suite('Users', function() {
-
 	beforeEach(function (done) {
-		database.db.query("TRUNCATE USERS", function(err) {
-			done();
+		// Because of foreign key constraints I can't just truncate :(
+		database.dropTables(function() {
+			database.createTables(done);
 		});
 	});
 


### PR DESCRIPTION
I would recommend testing this before accepting the pull request.

Configuration is now placed in db_config.json - it's pretty self explanatory.  By default the web app will run in development.  If you wish to change that prepend your command (ie: npm start) with NODE_ENV=development | test | production. Do note that by default test will delete all tables in its database.  You can force test and production to reset the database using FORCE_DROP=true before a command.  The web app must be on in test mode for tests to work.
